### PR TITLE
fix: switched result.date to result.send_at in job email condition

### DIFF
--- a/jobs/email.js
+++ b/jobs/email.js
@@ -51,7 +51,7 @@ const queue = require(queueFile);
       if (isCancelled) return;
 
       // if it's before the time we need to send the message then return early
-      if (Date.now() < new Date(result.date).getTime()) {
+      if (Date.now() < new Date(result.send_at).getTime()) {
         cabin.info('It it not time yet to send message', { result });
         return;
       }


### PR DESCRIPTION
Hey man, great library!

In the Job email at the condition, the attribute `date` was wrong, should be `send_at` in order to compare the date well, because in the `queue.js` the attribute is `send_at`.

```
 if (Date.now() < new Date(result.send_at).getTime()) {
        cabin.info('It it not time yet to send message', { result });
        return;
  }
```